### PR TITLE
Add scanning aliases with NMAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# VSCode IDE configs
+.vscode/
+*.code-workspace
+.history/

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ nudp [ip]
 nudpe [ip]
 
 # One-liners
-nscan [ip] # TCP all + TCP enum
-nfull [ip] # TCP all + TCP enum + UDP all + UDP enum
+nscan [ip] # TCP discovery + TCP enum on open ports
+nfull [ip] # TCP discovery + TCP enum + UDP discovery + UDP enum
 ```
 
 ## 📌 Getting Open Ports

--- a/README.md
+++ b/README.md
@@ -176,5 +176,5 @@ This project is licensed under the MIT License. See the LICENSE file for details
 
 # Working on...
 
-- Extracting specific port information from nmap output.
-- More functions to add hashes, etc.
+- Rustscan integration
+- More functions for bookeeping and automation

--- a/README.md
+++ b/README.md
@@ -160,8 +160,11 @@ nudp [ip]
 nudpe [ip]
 
 # One-liners
-nscan [ip] # TCP discovery + TCP enum on open ports
-nfull [ip] # TCP discovery + TCP enum + UDP discovery + UDP enum
+nscan       # Quiet discovery, then shows enum output
+nscan -v    # Normal discovery output + enum output
+
+nfull       # Quiet TCP+UDP discovery, then shows enum output
+nfull -v    # Normal TCP+UDP discovery output + enum output
 ```
 
 ## 📌 Getting Open Ports

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [🚀 Quick Start](#-quick-start)
 - [📝 Description](#-description)
 - [🔧 Commands](#-commands)
+- [🧭 Nmap Workflow](#-nmap-workflow)
 - [🌟 License](#-license)
 
 ---
@@ -119,6 +120,54 @@ vd  # Deactivates the Python virtual environment.
 vu  # Updates pip, setuptools, and wheel in the virtual environment.
 vr  # Installs dependencies from requirements.txt.
 init_venv  # Initializes a new Python virtual environment (alias for ve && va && vu && vr).
+```
+
+# 🧭 Nmap Workflow
+
+PentestManager includes an automated Nmap workflow that:
+- Stores scan outputs under: `<target>/enum/nmap/`
+- Saves discovered ports to `tcp_ports.txt` and `udp_ports.txt`.
+- Reuses saved ports automatically in subsequent scans
+
+## 📁 Nmap Output Files
+
+After running scans, you’ll typically have:
+```
+target/enum/nmap/
+├── allports_tcp.nmap   # Full TCP scan output
+├── tcp.nmap            # TCP scan of open ports only
+├── tcp_ports.txt       # List of open TCP ports
+├── allports_udp.nmap   # Full UDP scan output
+├── udp.nmap            # UDP scan of open ports only
+└── udp_ports.txt       # List of open UDP ports
+```
+
+## ⚡ Nmap Commands
+
+These commands use the saved target IP by default (from `loot/ip.txt`), but you can also pass an IP as an argument.
+
+```bash
+# Full TCP port discovery (saves ports to tcp_ports.txt) 
+ntcp [ip]
+
+# TCP enumeration (-sVC) using saved ports
+ntcpe [ip]
+
+# Full UDP scan (saves ports to udp_ports.txt)
+nudp [ip]
+
+# UDP enumeration (-sU -sVC) using saved ports
+nudpe [ip]
+
+# One-liners
+nscan [ip] # TCP all + TCP enum
+nfull [ip] # TCP all + TCP enum + UDP all + UDP enum
+```
+
+## 📌 Getting Open Ports
+
+```bash
+get_ports [tcp|udp|all] # tcp only, udp only, or combined (deduped) list
 ```
 
 # 🌟 License

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -2,6 +2,14 @@
 _info() {
     printf "\033[0;32m[+] %s\033[0m\n" "$*"
 }
+# Yellow warning messages
+_warn() {
+    printf "\033[0;33m[!] %s\033[0m\n" "$*"
+}
+# Red error messages
+_err() {
+    printf "\033[0;31m[-] %s\033[0m\n" "$*"
+}
 
 # Source all the aliases from the zsh_aliases directory
 alias sb="source ~/.zshrc"
@@ -29,7 +37,7 @@ _get_loot_dir() {
     if [[ -f ~/.current_loot_dir ]]; then
         cat ~/.current_loot_dir
     else
-        echo "No current target set. Use init_target/set_target first."
+        _err "No current target set. Use init_target/set_target first."
         return 1
     fi
 }
@@ -39,7 +47,7 @@ _get_target_dir() {
     if [[ -f ~/.current_target ]]; then
         cat ~/.current_target
     else
-        echo "No current target set. Use init_target/set_target first."
+        _err "No current target set. Use init_target/set_target first."
         return 1
     fi
 }
@@ -58,7 +66,7 @@ _get_ip() {
     if [[ -f "$loot_dir/ip.txt" ]]; then
         cat "$loot_dir/ip.txt"
     else
-        echo "No IP set for current target. Use: set_ip <ip>"
+        _err "No IP set for current target. Use: set_ip <ip>"
         return 1
     fi
 }
@@ -101,7 +109,7 @@ nmap_tcp_all() {
         echo -n "$ports" | xclip -selection clipboard -in -n
         _info "Saved TCP ports -> $dir/tcp_ports.txt (copied to clipboard): $ports"
     else
-        echo "No open TCP ports parsed from: $out"
+        _err "No open TCP ports parsed from: $out"
         return 1
     fi
 }
@@ -119,11 +127,13 @@ nmap_tcp_enum() {
     fi
 
     if [[ -z "$ports" ]]; then
-        echo "No TCP ports file found. Run: nmap_tcp_all [ip]"
+        _err "No TCP ports file found. Run: ntcp [ip]"
         return 1
     fi
 
     sudo nmap -sVC -p"$ports" -oN "$dir/tcp.nmap" "$ip" -vv --privileged
+
+    _info "TCP enum saved in: $dir/tcp.nmap"
 }
 
 # UDP: full scan -> saves udp_ports.txt
@@ -141,7 +151,7 @@ nmap_udp_all() {
         echo -n "$ports" | xclip -selection clipboard -in -n
         _info "Saved UDP ports -> $dir/udp_ports.txt (copied to clipboard): $ports"
     else
-        echo "No open/open|filtered UDP ports parsed from: $out"
+        _err "No open/open|filtered UDP ports parsed from: $out"
         return 1
     fi
 }
@@ -159,11 +169,12 @@ nmap_udp_enum() {
     fi
 
     if [[ -z "$ports" ]]; then
-        echo "No UDP ports file found. Run: nmap_udp_all [ip]"
+        _err "No UDP ports file found. Run: nudp [ip]"
         return 1
     fi
 
     sudo nmap -sU -sVC -p"$ports" -oN "$dir/udp.nmap" "$ip" -vv --privileged
+    _info "UDP enum saved in: $dir/udp.nmap"
 }
 
 # One-liners
@@ -183,7 +194,7 @@ get_ports_tcp() {
         echo -n "$ports" | xclip -selection clipboard -in -n
         _info "TCP ports copied to clipboard."
     else
-        echo "No tcp_ports.txt found. Run: nmap_tcp_all [ip]"
+        _err "No tcp_ports.txt found. Run: ntcp [ip]"
         return 1
     fi
 }
@@ -196,7 +207,7 @@ get_ports_udp() {
         echo -n "$ports" | xclip -selection clipboard -in -n
         _info "UDP ports copied to clipboard."
     else
-        echo "No udp_ports.txt found. Run: nmap_udp_all [ip]"
+        _err "No udp_ports.txt found. Run: nudp [ip]"
         return 1
     fi
 }
@@ -227,7 +238,7 @@ get_ports() {
             [[ -f "$dir/udp_ports.txt" ]] && udp="$(cat "$dir/udp_ports.txt")"
 
             if [[ -z "$tcp" && -z "$udp" ]]; then
-                echo "No saved ports found. Run ntcp/nudp (or nfull) first."
+                _warn "No saved ports found. Run ntcp/nudp (or nfull) first."
                 return 1
             fi
 
@@ -242,7 +253,7 @@ get_ports() {
             _info "TCP+UDP ports copied to clipboard."
             ;;
         *)
-            echo "Usage: get_ports [tcp|udp|all]"
+            _err "Usage: get_ports [tcp|udp|all]"
             return 1
             ;;
     esac
@@ -268,7 +279,7 @@ extract_ports() {
         | paste -sd ',' -)
 
     if [[ -z "$ports" ]]; then
-        echo "No ports found in input."
+        _warn "No ports found in input."
         return 1
     fi
 
@@ -307,7 +318,7 @@ init_target() {
     TARGET_DIR="$(pwd)"
     echo "$TARGET_DIR" > ~/.current_target
     cd enum || return
-    echo "Target '$target' initialized and set as current target."
+    _info "Target '$target' initialized and set as current target."
 }
 
 # To set the current target
@@ -315,7 +326,7 @@ init_target() {
 set_target() {
     local target="$1"
     if [ -z "$target" ]; then
-        echo "Usage: set_target <target_dir>"
+        _err "Usage: set_target <target_dir>"
         return 1
     fi
     # Resolve the absolute path of the target directory
@@ -325,9 +336,9 @@ set_target() {
         local loot_dir="$target_dir/loot"
         echo "$loot_dir" > ~/.current_loot_dir
         echo "$target_dir" > ~/.current_target
-        echo "Current target set to '$target_dir'"
+        _info "Current target set to '$target_dir'"
     else
-        echo "Target directory '$target_dir' does not exist."
+        _err "Target directory '$target_dir' does not exist."
         return 1
     fi
 }
@@ -344,7 +355,7 @@ add_user() {
         local LOOT_DIR
         LOOT_DIR="$(cat ~/.current_loot_dir)"
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _err "No current target set. Please initialize or set a target with set_target or init_target."
         return 1
     fi
 
@@ -361,7 +372,7 @@ add_user() {
             echo "$user" >> "$users_commented_file"
         fi
     else
-        echo "User '$user' is already known"
+        _warn "User '$user' is already known"
         return 1
     fi
 
@@ -373,7 +384,7 @@ add_user() {
         echo "$user" >> "$usersandpasses_file"
     fi
 
-    echo "User added: $user"
+    _info "User added: $user"
 }
 
 # To add password to passwords list and to usersandpasses list
@@ -388,7 +399,7 @@ add_pass() {
         local LOOT_DIR
         LOOT_DIR="$(cat ~/.current_loot_dir)"
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _err "No current target set. Please initialize or set a target with set_target or init_target."
         return 1
     fi
 
@@ -405,7 +416,7 @@ add_pass() {
             echo "$pass" >> "$passwords_commented_file"
         fi
     else
-        echo "Password is already known"
+        _warn "Password is already known"
         return 1
     fi
 
@@ -417,7 +428,7 @@ add_pass() {
         echo "$pass" >> "$usersandpasses_file"
     fi
 
-    echo "Password added: $pass"
+    _info "Password added: $pass"
 }
 
 # To add user:password to creds and related files
@@ -433,7 +444,7 @@ add_creds() {
         local LOOT_DIR
         LOOT_DIR="$(cat ~/.current_loot_dir)"
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _err "No current target set. Please initialize or set a target with set_target or init_target."
         return 1
     fi
 
@@ -449,7 +460,7 @@ add_creds() {
     # Normalize the format of the credential (no comment included in this check)
     local normalized_cred="$user:$pass"
     if grep -q "^${normalized_cred}$" "$creds_file" 2>/dev/null; then
-        echo "Credentials '$normalized_cred' are already known"
+        _warn "Credentials '$normalized_cred' are already known"
         return 1
     fi
 
@@ -467,7 +478,7 @@ add_creds() {
     add_user "$user" "$comment"
     add_pass "$pass" "$comment"
 
-    echo "Credentials added: $normalized_cred"
+    _info "Credentials added: $normalized_cred"
 }
 
 
@@ -476,7 +487,7 @@ get_target() {
     if [ -f ~/.current_target ]; then
         cat ~/.current_target
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _warn "No current target set. Please initialize or set a target with set_target or init_target."
     fi
 }
 
@@ -492,7 +503,7 @@ get_users() {
         if [ -f ~/.current_loot_dir ]; then
             loot_dir="$(cat ~/.current_loot_dir)"
         else
-            echo "No current target set. Please initialize or set a target with set_target or init_target."
+            _err "No current target set. Please initialize or set a target with set_target or init_target."
             return 1
         fi
     else
@@ -501,7 +512,7 @@ get_users() {
         target_dir="$(realpath "$target")"
         loot_dir="$target_dir/loot"
         if [ ! -d "$loot_dir" ]; then
-            echo "Loot directory for target '$target' does not exist."
+            _err "Loot directory for target '$target' does not exist."
             return 1
         fi
     fi
@@ -511,7 +522,7 @@ get_users() {
         echo "Users for target '${target:-$(cat ~/.current_target)}':"
         cat "$users_commented_file"
     else
-        echo "No users_commented.txt file found in $loot_dir"
+        _warn "No users_commented.txt file found in $loot_dir"
     fi
 }
 
@@ -527,7 +538,7 @@ get_passwords() {
         if [ -f ~/.current_loot_dir ]; then
             loot_dir="$(cat ~/.current_loot_dir)"
         else
-            echo "No current target set. Please initialize or set a target with set_target or init_target."
+            _err "No current target set. Please initialize or set a target with set_target or init_target."
             return 1
         fi
     else
@@ -536,7 +547,7 @@ get_passwords() {
         target_dir="$(realpath "$target")"
         loot_dir="$target_dir/loot"
         if [ ! -d "$loot_dir" ]; then
-            echo "Loot directory for target '$target' does not exist."
+            _err "Loot directory for target '$target' does not exist."
             return 1
         fi
     fi
@@ -546,7 +557,7 @@ get_passwords() {
         echo "Passwords for target '${target:-$(cat ~/.current_target)}':"
         cat "$passwords_commented_file"
     else
-        echo "No passwords_commented.txt file found in $loot_dir"
+        _warn "No passwords_commented.txt file found in $loot_dir"
     fi
 }
 
@@ -562,7 +573,7 @@ get_creds() {
         if [ -f ~/.current_loot_dir ]; then
             loot_dir="$(cat ~/.current_loot_dir)"
         else
-            echo "No current target set. Please initialize or set a target with set_target or init_target."
+            _err "No current target set. Please initialize or set a target with set_target or init_target."
             return 1
         fi
     else
@@ -571,7 +582,7 @@ get_creds() {
         target_dir="$(realpath "$target")"
         loot_dir="$target_dir/loot"
         if [ ! -d "$loot_dir" ]; then
-            echo "Loot directory for target '$target' does not exist."
+            _err "Loot directory for target '$target' does not exist."
             return 1
         fi
     fi
@@ -581,7 +592,7 @@ get_creds() {
         echo "Credentials for target '${target:-$(cat ~/.current_target)}':"
         cat "$creds_commented_file"
     else
-        echo "No creds_commented.txt file found in $loot_dir"
+        _warn "No creds_commented.txt file found in $loot_dir"
     fi
 }
 
@@ -590,7 +601,7 @@ get_creds() {
 set_ip() {
     local ip="$1"
     if [ -z "$ip" ]; then
-        echo "Usage: set_ip <ip_address>"
+        _err "Usage: set_ip <ip_address>"
         return 1
     fi
 
@@ -599,13 +610,13 @@ set_ip() {
         local LOOT_DIR
         LOOT_DIR="$(cat ~/.current_loot_dir)"
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _err "No current target set. Please initialize or set a target with set_target or init_target."
         return 1
     fi
 
     # Save the IP address to a file in the loot directory
     echo "$ip" > "$LOOT_DIR/ip.txt"
-    echo "IP address for target '$(cat ~/.current_target)' set to $ip"
+    _info "IP address for target '$(cat ~/.current_target)' set to $ip"
 }
 
 # To get the IP address for the current target or specified target
@@ -621,7 +632,7 @@ get_ip() {
             loot_dir="$(cat ~/.current_loot_dir)"
             target="$(cat ~/.current_target)"
         else
-            echo "No current target set. Please initialize or set a target with set_target or init_target."
+            _err "No current target set. Please initialize or set a target with set_target or init_target."
             return 1
         fi
     else
@@ -630,7 +641,7 @@ get_ip() {
         target_dir="$(realpath "$target")"
         loot_dir="$target_dir/loot"
         if [ ! -d "$loot_dir" ]; then
-            echo "Loot directory for target '$target' does not exist."
+            _err "Loot directory for target '$target' does not exist."
             return 1
         fi
     fi
@@ -641,9 +652,9 @@ get_ip() {
         ip="$(cat "$loot_dir/ip.txt")"
         echo "IP address for target '$target': $ip"
         echo -n "$ip" | xclip -selection clipboard -in -n
-        echo "IP address copied to clipboard."
+        _info "IP address copied to clipboard."
     else
-        echo "No IP address set for target '$target'. Use set_ip to set one."
+        _err "No IP address set for target '$target'. Use set_ip to set one."
         return 1
     fi
 }
@@ -656,21 +667,21 @@ clear_loot() {
         local LOOT_DIR
         LOOT_DIR="$(cat ~/.current_loot_dir)"
     else
-        echo "No current target set. Please initialize or set a target with set_target or init_target."
+        _err "No current target set. Please initialize or set a target with set_target or init_target."
         return 1
     fi
 
     # Check if LOOT_DIR exists
     if [ ! -d "$LOOT_DIR" ]; then
-        echo "Loot directory '$LOOT_DIR' does not exist. Please ensure the target is correctly set."
+        _err "Loot directory '$LOOT_DIR' does not exist. Please ensure the target is correctly set."
         return 1
     fi
 
     # Prompt for confirmation
-    echo "Are you sure you want to clear all users, passwords, and creds? (y/n):"
+    _warn "Are you sure you want to clear all users, passwords, and creds? (y/n):"
     read confirm
     if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-        echo "Aborting."
+        _warn "Aborting."
         return 0
     fi
 
@@ -692,5 +703,5 @@ clear_loot() {
     : > "$creds_commented_file" 2>/dev/null
     : > "$usersandpasses_file" 2>/dev/null
 
-    echo "All users, passwords, and creds have been cleared."
+    _info "All users, passwords, and creds have been cleared."
 }

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -317,7 +317,7 @@ extract_ports() {
     local input="$1"
     local ports
     ports=$(echo "$input" \
-        | grep -E '^[0-9]+/(tcp|udp)[[:space:]]' \
+        | grep -E '^[[:space:]]*[0-9]+/(tcp|udp)[[:space:]]' \
         | awk -F'/' '{print $1}' \
         | paste -sd ',' -)
 

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -18,6 +18,228 @@ crack() {
 }
 
 
+# Target Scanning (NMAP)
+# Internal: get current loot dir (quietly) and error if not set
+_get_loot_dir() {
+    if [[ -f ~/.current_loot_dir ]]; then
+        cat ~/.current_loot_dir
+    else
+        echo "No current target set. Use init_target/set_target first."
+        return 1
+    fi
+}
+
+# Internal: get current target dir (quietly) and error if not set
+_get_target_dir() {
+    if [[ -f ~/.current_target ]]; then
+        cat ~/.current_target
+    else
+        echo "No current target set. Use init_target/set_target first."
+        return 1
+    fi
+}
+
+# Internal: get IP (arg > saved ip.txt)
+_get_ip() {
+    local ip="$1"
+    if [[ -n "$ip" ]]; then
+        echo "$ip"
+        return 0
+    fi
+
+    local loot_dir
+    loot_dir="$(_get_loot_dir)" || return 1
+
+    if [[ -f "$loot_dir/ip.txt" ]]; then
+        cat "$loot_dir/ip.txt"
+    else
+        echo "No IP set for current target. Use: set_ip <ip>"
+        return 1
+    fi
+}
+
+# Internal: where to store nmap outputs for the current target
+_get_nmap_dir() {
+    local tdir
+    tdir="$(_get_target_dir)" || return 1
+    local d="$tdir/enum/nmap"
+    mkdir -p "$d"
+    echo "$d"
+}
+
+# Internal: parse ports from nmap normal output
+_parse_tcp_ports() {
+    local file="$1"
+    grep -E '^[0-9]+/tcp[[:space:]]+open' "$file" 2>/dev/null \
+      | awk -F'/' '{print $1}' | paste -sd ',' -
+}
+
+_parse_udp_ports() {
+    local file="$1"
+    # include open and open|filtered (common in UDP)
+    grep -E '^[0-9]+/udp[[:space:]]+(open|open\|filtered)' "$file" 2>/dev/null \
+      | awk -F'/' '{print $1}' | paste -sd ',' -
+}
+
+# TCP: full port discovery -> saves tcp_ports.txt
+nmap_tcp_all() {
+    local ip dir out ports
+    ip="$(_get_ip "$1")" || return 1
+    dir="$(_get_nmap_dir)" || return 1
+
+    out="$dir/allports_tcp.nmap"
+    sudo nmap -p- -T3 -oN "$out" "$ip" -vv --privileged
+
+    ports="$(_parse_tcp_ports "$out")"
+    if [[ -n "$ports" ]]; then
+        echo "$ports" > "$dir/tcp_ports.txt"
+        echo -n "$ports" | xclip -selection clipboard -in -n
+        echo "Saved TCP ports -> $dir/tcp_ports.txt (copied to clipboard): $ports"
+    else
+        echo "No open TCP ports parsed from: $out"
+        return 1
+    fi
+}
+
+# TCP: enum (-sVC) using saved ports (or parses last full scan if needed)
+nmap_tcp_enum() {
+    local ip dir ports
+    ip="$(_get_ip "$1")" || return 1
+    dir="$(_get_nmap_dir)" || return 1
+
+    if [[ -f "$dir/tcp_ports.txt" ]]; then
+        ports="$(cat "$dir/tcp_ports.txt")"
+    elif [[ -f "$dir/allports_tcp.nmap" ]]; then
+        ports="$(_parse_tcp_ports "$dir/allports_tcp.nmap")"
+    fi
+
+    if [[ -z "$ports" ]]; then
+        echo "No TCP ports file found. Run: nmap_tcp_all [ip]"
+        return 1
+    fi
+
+    sudo nmap -sVC -p"$ports" -oN "$dir/tcp.nmap" "$ip" -vv --privileged
+}
+
+# UDP: full scan -> saves udp_ports.txt
+nmap_udp_all() {
+    local ip dir out ports
+    ip="$(_get_ip "$1")" || return 1
+    dir="$(_get_nmap_dir)" || return 1
+
+    out="$dir/allports_udp.nmap"
+    sudo nmap -sU -p- -T5 --min-rate=10000 -oN "$out" "$ip" -vv --privileged
+
+    ports="$(_parse_udp_ports "$out")"
+    if [[ -n "$ports" ]]; then
+        echo "$ports" > "$dir/udp_ports.txt"
+        echo -n "$ports" | xclip -selection clipboard -in -n
+        echo "Saved UDP ports -> $dir/udp_ports.txt (copied to clipboard): $ports"
+    else
+        echo "No open/open|filtered UDP ports parsed from: $out"
+        return 1
+    fi
+}
+
+# UDP: enum common UDP services using saved UDP ports
+nmap_udp_enum() {
+    local ip dir ports
+    ip="$(_get_ip "$1")" || return 1
+    dir="$(_get_nmap_dir)" || return 1
+
+    if [[ -f "$dir/udp_ports.txt" ]]; then
+        ports="$(cat "$dir/udp_ports.txt")"
+    elif [[ -f "$dir/allports_udp.nmap" ]]; then
+        ports="$(_parse_udp_ports "$dir/allports_udp.nmap")"
+    fi
+
+    if [[ -z "$ports" ]]; then
+        echo "No UDP ports file found. Run: nmap_udp_all [ip]"
+        return 1
+    fi
+
+    sudo nmap -sU -sVC -p"$ports" -oN "$dir/udp.nmap" "$ip" -vv --privileged
+}
+
+# One-liners
+nmap_scan() { nmap_tcp_all "$1" && nmap_tcp_enum "$1"; }
+nmap_scan_full() { nmap_scan "$1" && nmap_udp_all "$1" && nmap_udp_enum "$1"; }
+
+# Quick access to saved ports (copies to clipboard too)
+get_ports_tcp() {
+    local dir="$(_get_nmap_dir)" || return 1
+    if [[ -f "$dir/tcp_ports.txt" ]]; then
+        local ports="$(cat "$dir/tcp_ports.txt")"
+        echo "$ports"
+        echo -n "$ports" | xclip -selection clipboard -in -n
+        echo "TCP ports copied to clipboard."
+    else
+        echo "No tcp_ports.txt found. Run: nmap_tcp_all [ip]"
+        return 1
+    fi
+}
+
+get_ports_udp() {
+    local dir="$(_get_nmap_dir)" || return 1
+    if [[ -f "$dir/udp_ports.txt" ]]; then
+        local ports="$(cat "$dir/udp_ports.txt")"
+        echo "$ports"
+        echo -n "$ports" | xclip -selection clipboard -in -n
+        echo "UDP ports copied to clipboard."
+    else
+        echo "No udp_ports.txt found. Run: nmap_udp_all [ip]"
+        return 1
+    fi
+}
+
+# Aliases
+alias ntcp="nmap_tcp_all"       # full TCP
+alias ntcpe="nmap_tcp_enum"     # enum TCP (uses saved ports)
+alias nudp="nmap_udp_all"       # full UDP
+alias nudpe="nmap_udp_enum"     # enum UDP (uses saved ports)
+alias nscan="nmap_scan"         # TCP all + enum
+alias nfull="nmap_scan_full"    # TCP all + enum + UDP all + enum
+
+# Wrapper: get ports easily
+# Usage:
+#   get_ports            # both (tcp+udp)
+#   get_ports tcp        # tcp only
+#   get_ports udp        # udp only
+get_ports() {
+    local mode="${1:-all}"
+    case "$mode" in
+        tcp) get_ports_tcp ;;
+        udp) get_ports_udp ;;
+        all)
+            local dir="$(_get_nmap_dir)" || return 1
+            local tcp="" udp="" combined=""
+
+            [[ -f "$dir/tcp_ports.txt" ]] && tcp="$(cat "$dir/tcp_ports.txt")"
+            [[ -f "$dir/udp_ports.txt" ]] && udp="$(cat "$dir/udp_ports.txt")"
+
+            if [[ -z "$tcp" && -z "$udp" ]]; then
+                echo "No saved ports found. Run ntcp/nudp (or nfull) first."
+                return 1
+            fi
+
+            # Combine and de-duplicate
+            combined="$(printf "%s\n%s\n" "$tcp" "$udp" \
+                | tr ',' '\n' \
+                | awk 'NF && !seen[$0]++' \
+                | paste -sd ',' -)"
+
+            echo "$combined"
+            echo -n "$combined" | xclip -selection clipboard -in -n
+            echo "TCP+UDP ports copied to clipboard."
+            ;;
+        *)
+            echo "Usage: get_ports [tcp|udp|all]"
+            return 1
+            ;;
+    esac
+}
+
+
 # Extract ports addresses from nmap output
 # e.g. extract_ports "53/tcp    open  domain           syn-ack ttl 125
 #      88/tcp    open  kerberos-sec     syn-ack ttl 125
@@ -29,9 +251,19 @@ crack() {
 #
 # >> Output: 53,88,135,139,389,445,464
 extract_ports() {
+    local input="$1"
     local ports
-    ports=$(echo "$1" | awk -F'/' '{print $1}' | paste -sd ',' -)
-    printf "%s" "$ports" | xclip -selection clipboard
+    ports=$(echo "$input" \
+        | grep -E '^[0-9]+/(tcp|udp)[[:space:]]' \
+        | awk -F'/' '{print $1}' \
+        | paste -sd ',' -)
+
+    if [[ -z "$ports" ]]; then
+        echo "No ports found in input."
+        return 1
+    fi
+
+    printf "%s" "$ports" | xclip -selection clipboard -in -n
     echo "Ports copied to clipboard: $ports"
 }
 

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -119,9 +119,9 @@ nmap_tcp_all() {
     out="$dir/allports_tcp.nmap"
 
     if [[ $VERBOSE -eq 1 ]]; then
-        sudo nmap -p- -T3 -oN "$out" "$ip" --privileged
+        sudo nmap -p- -T4 -oN "$out" "$ip" --privileged
     else
-        sudo nmap -p- -T3 -oN "$out" "$ip" --privileged >/dev/null 2>"$out.err"
+        sudo nmap -p- -T4 -oN "$out" "$ip" --privileged >/dev/null 2>"$out.err"
     fi
 
     if [[ $? -ne 0 ]]; then

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -32,6 +32,22 @@ crack() {
 
 
 # Target Scanning (NMAP)
+# If you call: ntcp -v   OR   nfull --verbose
+_is_verbose() { [[ "$1" == "-v" || "$1" == "--verbose" ]]; }
+
+_parse_scan_args() {
+    typeset -g VERBOSE IP_ARG
+    VERBOSE=0
+    IP_ARG=""
+    for a in "$@"; do
+        if _is_verbose "$a"; then
+            VERBOSE=1
+        else
+            IP_ARG="$a"
+        fi
+    done
+}
+
 # Internal: get current loot dir (quietly) and error if not set
 _get_loot_dir() {
     if [[ -f ~/.current_loot_dir ]]; then
@@ -97,28 +113,42 @@ _parse_udp_ports() {
 # TCP: full port discovery -> saves tcp_ports.txt
 nmap_tcp_all() {
     local ip dir out ports
-    ip="$(_get_ip "$1")" || return 1
+    _parse_scan_args "$@"
+    ip="$(_get_ip "$IP_ARG")" || return 1
     dir="$(_get_nmap_dir)" || return 1
-
     out="$dir/allports_tcp.nmap"
-    sudo nmap -p- -T3 -oN "$out" "$ip" -vv --privileged
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        sudo nmap -p- -T3 -oN "$out" "$ip" --privileged
+    else
+        sudo nmap -p- -T3 -oN "$out" "$ip" --privileged >/dev/null 2>"$out.err"
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        _err "TCP discovery failed. Re-run with -v, or check: $out.err"
+        return 1
+    fi
 
     ports="$(_parse_tcp_ports "$out")"
     if [[ -n "$ports" ]]; then
         echo "$ports" > "$dir/tcp_ports.txt"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        _info "Saved TCP ports -> $dir/tcp_ports.txt (copied to clipboard): $ports"
+        _info "Saved TCP ports -> $dir/tcp_ports.txt (copied): $ports"
     else
         _err "No open TCP ports parsed from: $out"
+        _warn "Tip: re-run with -v to see live output (ntcp -v)"
         return 1
     fi
 }
 
 # TCP: enum (-sVC) using saved ports (or parses last full scan if needed)
 nmap_tcp_enum() {
-    local ip dir ports
-    ip="$(_get_ip "$1")" || return 1
+    local ip dir ports vflag=""
+    _parse_scan_args "$@"
+    ip="$(_get_ip "$IP_ARG")" || return 1
     dir="$(_get_nmap_dir)" || return 1
+
+    [[ $VERBOSE -eq 1 ]] && vflag="-vv"
 
     if [[ -f "$dir/tcp_ports.txt" ]]; then
         ports="$(cat "$dir/tcp_ports.txt")"
@@ -131,36 +161,49 @@ nmap_tcp_enum() {
         return 1
     fi
 
-    sudo nmap -sVC -p"$ports" -oN "$dir/tcp.nmap" "$ip" -vv --privileged
-
+    sudo nmap -sVC ${vflag:+$vflag} -p"$ports" -oN "$dir/tcp.nmap" "$ip" --privileged
     _info "TCP enum saved in: $dir/tcp.nmap"
 }
 
 # UDP: full scan -> saves udp_ports.txt
 nmap_udp_all() {
     local ip dir out ports
-    ip="$(_get_ip "$1")" || return 1
+    _parse_scan_args "$@"
+    ip="$(_get_ip "$IP_ARG")" || return 1
     dir="$(_get_nmap_dir)" || return 1
-
     out="$dir/allports_udp.nmap"
-    sudo nmap -sU -p- -T5 --min-rate=10000 -oN "$out" "$ip" -vv --privileged
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        sudo nmap -sU -p- -T5 --min-rate=10000 -oN "$out" "$ip" --privileged
+    else
+        sudo nmap -sU -p- -T5 --min-rate=10000 -oN "$out" "$ip" --privileged >/dev/null 2>"$out.err"
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        _err "UDP discovery failed. Re-run with -v, or check: $out.err"
+        return 1
+    fi
 
     ports="$(_parse_udp_ports "$out")"
     if [[ -n "$ports" ]]; then
         echo "$ports" > "$dir/udp_ports.txt"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        _info "Saved UDP ports -> $dir/udp_ports.txt (copied to clipboard): $ports"
+        _info "Saved UDP ports -> $dir/udp_ports.txt (copied): $ports"
     else
         _err "No open/open|filtered UDP ports parsed from: $out"
+        _warn "Tip: re-run with -v to see live output (nudp -v)"
         return 1
     fi
 }
 
 # UDP: enum common UDP services using saved UDP ports
 nmap_udp_enum() {
-    local ip dir ports
-    ip="$(_get_ip "$1")" || return 1
+    local ip dir ports vflag=""
+    _parse_scan_args "$@"
+    ip="$(_get_ip "$IP_ARG")" || return 1
     dir="$(_get_nmap_dir)" || return 1
+
+    [[ $VERBOSE -eq 1 ]] && vflag="-vv"
 
     if [[ -f "$dir/udp_ports.txt" ]]; then
         ports="$(cat "$dir/udp_ports.txt")"
@@ -173,16 +216,16 @@ nmap_udp_enum() {
         return 1
     fi
 
-    sudo nmap -sU -sVC -p"$ports" -oN "$dir/udp.nmap" "$ip" -vv --privileged
+    sudo nmap -sU -sVC $vflag -p"$ports" -oN "$dir/udp.nmap" "$ip" --privileged
     _info "UDP enum saved in: $dir/udp.nmap"
 }
 
 # One-liners
 nmap_scan() {
-    nmap_tcp_all "$1" && nmap_tcp_enum "$1" && _info "Scan complete. Results saved in: $(_get_nmap_dir)"
+    nmap_tcp_all "$@" && nmap_tcp_enum "$@" && _info "Scan complete. Results saved in: $(_get_nmap_dir)"
 }
 nmap_scan_full() {
-    nmap_scan "$1" && nmap_udp_all "$1" && nmap_udp_enum "$1" && _info "Full scan complete. Results saved in: $(_get_nmap_dir)"
+    nmap_scan "$@" && nmap_udp_all "$@" && nmap_udp_enum "$@" && _info "Full scan complete. Results saved in: $(_get_nmap_dir)"
 }
 
 # Quick access to saved ports (copies to clipboard too)

--- a/pentest_aliases.sh
+++ b/pentest_aliases.sh
@@ -1,3 +1,8 @@
+# Green info messages
+_info() {
+    printf "\033[0;32m[+] %s\033[0m\n" "$*"
+}
+
 # Source all the aliases from the zsh_aliases directory
 alias sb="source ~/.zshrc"
 
@@ -94,7 +99,7 @@ nmap_tcp_all() {
     if [[ -n "$ports" ]]; then
         echo "$ports" > "$dir/tcp_ports.txt"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        echo "Saved TCP ports -> $dir/tcp_ports.txt (copied to clipboard): $ports"
+        _info "Saved TCP ports -> $dir/tcp_ports.txt (copied to clipboard): $ports"
     else
         echo "No open TCP ports parsed from: $out"
         return 1
@@ -134,7 +139,7 @@ nmap_udp_all() {
     if [[ -n "$ports" ]]; then
         echo "$ports" > "$dir/udp_ports.txt"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        echo "Saved UDP ports -> $dir/udp_ports.txt (copied to clipboard): $ports"
+        _info "Saved UDP ports -> $dir/udp_ports.txt (copied to clipboard): $ports"
     else
         echo "No open/open|filtered UDP ports parsed from: $out"
         return 1
@@ -162,8 +167,12 @@ nmap_udp_enum() {
 }
 
 # One-liners
-nmap_scan() { nmap_tcp_all "$1" && nmap_tcp_enum "$1"; }
-nmap_scan_full() { nmap_scan "$1" && nmap_udp_all "$1" && nmap_udp_enum "$1"; }
+nmap_scan() {
+    nmap_tcp_all "$1" && nmap_tcp_enum "$1" && _info "Scan complete. Results saved in: $(_get_nmap_dir)"
+}
+nmap_scan_full() {
+    nmap_scan "$1" && nmap_udp_all "$1" && nmap_udp_enum "$1" && _info "Full scan complete. Results saved in: $(_get_nmap_dir)"
+}
 
 # Quick access to saved ports (copies to clipboard too)
 get_ports_tcp() {
@@ -172,7 +181,7 @@ get_ports_tcp() {
         local ports="$(cat "$dir/tcp_ports.txt")"
         echo "$ports"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        echo "TCP ports copied to clipboard."
+        _info "TCP ports copied to clipboard."
     else
         echo "No tcp_ports.txt found. Run: nmap_tcp_all [ip]"
         return 1
@@ -185,7 +194,7 @@ get_ports_udp() {
         local ports="$(cat "$dir/udp_ports.txt")"
         echo "$ports"
         echo -n "$ports" | xclip -selection clipboard -in -n
-        echo "UDP ports copied to clipboard."
+        _info "UDP ports copied to clipboard."
     else
         echo "No udp_ports.txt found. Run: nmap_udp_all [ip]"
         return 1
@@ -230,7 +239,7 @@ get_ports() {
 
             echo "$combined"
             echo -n "$combined" | xclip -selection clipboard -in -n
-            echo "TCP+UDP ports copied to clipboard."
+            _info "TCP+UDP ports copied to clipboard."
             ;;
         *)
             echo "Usage: get_ports [tcp|udp|all]"
@@ -264,7 +273,7 @@ extract_ports() {
     fi
 
     printf "%s" "$ports" | xclip -selection clipboard -in -n
-    echo "Ports copied to clipboard: $ports"
+    _info "Ports copied to clipboard: $ports"
 }
 
 # Venv aliases


### PR DESCRIPTION
This PR introduces a full Nmap workflow to PentestManager to streamline host discovery + service enumeration during engagements. It adds discovery + enumeration functions for TCP and UDP, persists results into the active target directory, and supports a -v/--verbose flag to optionally show live Nmap output (quiet discovery by default).